### PR TITLE
Add track descriptions to  2020 individual buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,9 +168,10 @@
                         </p>
                         <a class="btn btn-success btn-lg col-10 disabled"
                             href="https://solo-a-presidentscup.cisa.gov">Individual
-                            Track A</a>
+                            Track A<br/><small>Incident Response/Forensics</small></a>
                         <a class="btn btn-success btn-lg col-10 mt-2 disabled"
-                            href="https://solo-b-presidentscup.cisa.gov">Individual Track B</a>
+                            href="https://solo-b-presidentscup.cisa.gov">Individual
+                            Track B<br/><small>Exploitation/Vuln Assessment</small></a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Helps competitors keep the individual tracks straight instead of referring back to [cisa.gov/presidentscup](https://cisa.gov/presidentscup).